### PR TITLE
브라우저 화면이 숨겨져 있다가 드러났을 때의 동작을 개선하는 PR입니다.

### DIFF
--- a/app/chat/useChatList.ts
+++ b/app/chat/useChatList.ts
@@ -132,9 +132,7 @@ export default function useChatList(chatChannelId: string, accessToken: string, 
                         pendingChatListRef.current = []
                         setChatList(chats)
                     } else {
-                        pendingChatListRef.current = [...pendingChatListRef.current, ...chats].filter(
-                            ({time}, i) => i < maxChatLength || new Date().getTime() - time < 1000
-                        )
+                        pendingChatListRef.current = [...pendingChatListRef.current, ...chats].slice(-1 *  maxChatLength)
                     }
                     break
             }
@@ -159,16 +157,19 @@ export default function useChatList(chatChannelId: string, accessToken: string, 
 
     useEffect(() => {
         const interval = setInterval(() => {
+            if (document.hidden) {
+                return
+            }
             if (pendingChatListRef.current.length > 0) {
                 if (new Date().getTime() - lastSetTimestampRef.current > 1000) {
                     setChatList((prevChatList) => {
-                        return [...prevChatList, ...pendingChatListRef.current].slice(-1 * maxChatLength)
+                        const newChatList = [...prevChatList, ...pendingChatListRef.current].slice(-1 * maxChatLength)
+                        pendingChatListRef.current = []
+                        return newChatList
                     })
-                    pendingChatListRef.current = []
                 } else {
-                    const chat = pendingChatListRef.current.shift()
                     setChatList((prevChatList) => {
-                        const newChatList = [...prevChatList, chat]
+                        const newChatList = [...prevChatList, pendingChatListRef.current.shift()]
                         if (newChatList.length > maxChatLength) {
                             newChatList.shift()
                         }


### PR DESCRIPTION
- 브라우저 화면이 숨겨져 있을 때에는 `setChatList`를 호출하지 않고 버퍼에 계속 쌓이도록 했습니다. (OBS에서 장면 전환 테스트 완료했습니다)
   - 테스트를 해 보니 브라우저 화면이 숨겨져 있을 때에는 `setInterval`이 75ms보다 느리게 호출되거나 호출되지 않게 되더라고요. 그런데 사실 숨겨진 시점부터 호출되지 않는 것을 가정하고 작성한 로직이기도 하고, 화면이 숨겨져 있을 때에는 화면 업데이트를 하지 않는 것이 성능상 더 나으므로 이와 같이 작업하였습니다. (OBS에서 장면 전환 테스트 완료했습니다)
- `pendingChatListRef`가 `maxChatLength`보다 많이 쌓였을 때 오래된 메세지가 아닌 아닌 최근 메세지를 잘라내는 문제를 해결했습니다.
- 화면이 1초 이상 렌더링되지 않았을 때에 실행되는 코드에서 `setChatList`의 함수보다 `pendingChatListRef.current = []`가 먼저 실행되어 `chatList`가 업데이트되지 않던 문제를 해결했습니다.